### PR TITLE
[0.0.1+2] Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@ Initial release of the custom loading indicator dart package.
 ## [0.0.1+1] - 02/06/2020
 
 Added gif to pub.dev README.
+
+## [0.0.1+2] - 03/06/2020
+
+Added Sizes to the Loading Indicator. AUtomatically it defaults to 2. It can be between 1 and 6.
+Added Size Out of Bound Exception Handling in Error Widgets.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,7 +14,11 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      child: CustomCircularLoadingIndicator(imagePath: 'images/tooth.png',)  //curveName is an optional argument - an object of the Curves class in Flutter
-    );
+        child: CustomCircularLoadingIndicator(
+      imagePath: 'images/tooth.png',
+      size:
+          2, //size is an optional argument, by default it is set to 2 (It can be between 1 and 6)
+    ) //curveName is an optional argument - an object of the Curves class in Flutter
+        );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.11"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.5.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -87,7 +87,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.4"
   matcher:
     dependency: transitive
     description:
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -122,7 +129,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -134,7 +141,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -169,7 +176,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:
@@ -190,6 +197,6 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.1"
+    version: "3.5.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"

--- a/lib/Exceptions/SizeOutOfBoundException.dart
+++ b/lib/Exceptions/SizeOutOfBoundException.dart
@@ -1,0 +1,12 @@
+class SizeOutOfBoundException implements Exception {
+  String _message;
+
+  SizeOutOfBoundException([String message = "Size is out of Bounds"]) {
+    this._message = message;
+  }
+
+  @override
+  String toString() {
+    return _message;
+  }
+}

--- a/lib/custom_loading_indicator.dart
+++ b/lib/custom_loading_indicator.dart
@@ -1,55 +1,93 @@
 library custom_loading_indicator;
+
 import 'package:flutter/material.dart';
+import './Exceptions/SizeOutOfBoundException.dart';
 
 class CustomCircularLoadingIndicator extends StatefulWidget {
   final dynamic imagePath;
   final dynamic curveName;
-  CustomCircularLoadingIndicator({this.imagePath, this.curveName = Null});
+  final dynamic size;
+  CustomCircularLoadingIndicator(
+      {this.imagePath, this.curveName = Null, this.size = 2});
   @override
-  _CustomCircularLoadingIndicatorState createState() => _CustomCircularLoadingIndicatorState();
+  _CustomCircularLoadingIndicatorState createState() =>
+      _CustomCircularLoadingIndicatorState();
 }
 
-class _CustomCircularLoadingIndicatorState extends State<CustomCircularLoadingIndicator> with TickerProviderStateMixin {
+class _CustomCircularLoadingIndicatorState
+    extends State<CustomCircularLoadingIndicator>
+    with TickerProviderStateMixin {
   dynamic _animation;
   AnimationController _controller;
   String imagePath;
+  int size;
+
+  String errorMessage;
+
+  List<double> sizesList = [30, 45, 60, 80, 100, 120];
+
+  handleError(String error) {
+    if (mounted) {
+      setState(() {
+        errorMessage = error;
+      });
+    }
+  }
 
   @override
   void initState() {
     imagePath = widget.imagePath;
+    size = widget.size;
+    try {
+      validateSize(size);
+    } catch (e) {
+      handleError(e.toString());
+    }
     _controller =
         AnimationController(vsync: this, duration: Duration(seconds: 2));
     if (widget.curveName != Null) {
-      _animation = new Tween(begin: 0.5, end: 1.0).animate(
-        new CurvedAnimation(parent: _controller, curve: widget.curveName,)
-      );
-    }
-    else
-    {
+      _animation = new Tween(begin: 0.5, end: 1.0).animate(new CurvedAnimation(
+        parent: _controller,
+        curve: widget.curveName,
+      ));
+    } else {
       _animation = Null;
     }
     _controller.repeat();
     super.initState();
   }
 
+  void validateSize(int _size) {
+    if (_size == 0) {
+      throw new SizeOutOfBoundException("Size must not be 0");
+    } else if (_size < 0) {
+      throw new SizeOutOfBoundException("Size cannot be a negative value");
+    } else if (_size > 6) {
+      throw new SizeOutOfBoundException(
+          "Size should be less than or equal to 6");
+    }
+  }
+
   @override
   Widget build(BuildContext build) {
-    return MaterialApp(
-      home: RotationTransition(
-        turns: _animation == Null ? _controller : _animation,
-        child: Center(
-          child: Container(
-            width: 400.0,
-            height: 200.0,
-            alignment: Alignment.center,
-            child: CircleAvatar(
-              backgroundImage: AssetImage(imagePath),
-              radius: 45.0,
+    return errorMessage == null
+        ? MaterialApp(
+            home: RotationTransition(
+              turns: _animation == Null ? _controller : _animation,
+              child: Center(
+                child: Container(
+                  width: 400.0,
+                  height: 200.0,
+                  alignment: Alignment.center,
+                  child: CircleAvatar(
+                    backgroundImage: AssetImage(imagePath),
+                    radius: sizesList[size - 1],
+                  ),
+                ),
+              ),
             ),
-          ),
-        ),
-      ),
-    );
+          )
+        : ErrorWidget(errorMessage);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.11"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.5.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,7 +73,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.4"
   matcher:
     dependency: transitive
     description:
@@ -95,6 +95,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -108,7 +115,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +127,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -155,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:
@@ -176,6 +183,6 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.1"
+    version: "3.5.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Features added -

- **Size indicator** added as an _optional_ parameter. 
*Now users can choose the size of the loading indicator
By default the size is `2`. It can be anywhere between `1 to 6`.*
- Size Out of Bound Exception Handling has been created.
- Exception if caught would not just be visible on the terminal but also on the **Main UI** through **Error Widget**

**Image Preview with Size => 2**
<p align="center">
<img src="https://i.ibb.co/7JWkK1m/loading-indicator-preview1.png" alt="Preview 1" width="200"/>

**Image Preview with Size => 6** [Max]
<p align="center">
<img src="https://i.ibb.co/4dhPkNK/loading-indicator-preview2.png" alt="Preview 2" width="200"/>